### PR TITLE
Better triangle layout for intersecting header on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jumbocode-website",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "JumboCode website 2019",
   "main": "index.js",
   "scripts": {

--- a/src/sections/Landing.js
+++ b/src/sections/Landing.js
@@ -11,20 +11,20 @@ const Background = () => (
   <div>
     <Triangle
       color="backgroundDark"
-      height={['35vh', '80vh']}
+      height={['25vh', '80vh']}
       width={['95vw', '60vw']}
     />
 
     <Triangle
       color="secondary"
-      height={['38vh', '80vh']}
-      width={['50vw', '35vw']}
+      height={['30vh', '80vh']}
+      width={['50vw', '30vw']}
     />
 
     <Triangle
       color="primaryDark"
-      height={['25vh', '35vh']}
-      width={['75vw', '60vw']}
+      height={['35vh', '35vh']}
+      width={['90vw', '60vw']}
       invertX
     />
 


### PR DESCRIPTION
So that the white text is generally always behind a green background. 