### PR TITLE
Vertically align 'Jumbo' and 'Code' on landing page

### DIFF
--- a/src/sections/Landing.js
+++ b/src/sections/Landing.js
@@ -67,7 +67,9 @@ const LandingPage = () => {
               </Text>
             </Fade>
             <Fade delay={500}>
-              <Text color="primary">Code</Text>
+              <Text color="primary" style={{ marginTop: '2vw' }}>
+                Code
+              </Text>
             </Fade>
           </Flex>
         </Heading>


### PR DESCRIPTION
Add padding to the top of the Code div so that it lines up with Jumbo. This was happening for me on Edge and Chrome.

Old:
![jc-web-old](https://user-images.githubusercontent.com/28712163/61602832-08d22000-abf0-11e9-8d75-568f75568803.png)

New:
![jumbocodeweb](https://user-images.githubusercontent.com/28712163/61602835-0b347a00-abf0-11e9-9421-9c9625a37324.png)

Mobile new: 
<img width="225" alt="mobilejumbocode" src="https://user-images.githubusercontent.com/28712163/61602907-56e72380-abf0-11e9-809b-0a501b4dbe63.PNG">

