### PR TITLE
Browser Ttile Misalignment Fix

### DIFF
--- a/src/sections/Landing.js
+++ b/src/sections/Landing.js
@@ -62,14 +62,10 @@ const LandingPage = () => {
         >
           <Flex>
             <Fade>
-              <Text fontWeight="900" color="secondary">
-                Jumbo
-              </Text>
+              <Text color="secondary">Jumbo</Text>
             </Fade>
             <Fade delay={500}>
-              <Text color="primary" style={{ marginTop: '2vw' }}>
-                Code
-              </Text>
+              <Text color="primary">Code</Text>
             </Fade>
           </Flex>
         </Heading>


### PR DESCRIPTION
@wolfep15 the previous PR borked the alignment on my devices -- tested on Mac Firefox & Chrome, & iOS browsers, it pushes the view too far down. 

I have a feeling that the cause for this was the font bolding -- this actually didn't work on these devices, but seemingly did on the screenshots you gave. Can you take a look at the netlify demo site and see if this is fixed on your devices?

<img width="1391" alt="image" src="https://user-images.githubusercontent.com/25315679/61901295-68c90f00-aeed-11e9-8701-ecdefdc924eb.png">
