### PR TITLE
Configure webpack to process markdown files with raw-loader

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,12 @@
+exports.onCreateWebpackConfig = ({ actions }) => {
+  actions.setWebpackConfig({
+    module: {
+      rules: [
+        {
+          test: /\.md$/,
+          loader: 'raw-loader',
+        },
+      ],
+    },
+  });
+};

--- a/src/sections/About.js
+++ b/src/sections/About.js
@@ -5,7 +5,7 @@ import Fade from 'react-reveal/Fade';
 
 // TODO: Correctly install webpack to use raw-loader for markdown files
 // eslint-disable-next-line import/no-webpack-loader-syntax,  import/no-unresolved
-import AboutContentPath from 'raw-loader!../data/about.md';
+import AboutContentPath from '../data/about.md';
 import Section from '../components/Section';
 import Triangle from '../components/Triangle';
 import markdownRenderer from '../components/MarkdownRenderer';


### PR DESCRIPTION
Fixes #2 