### PR TITLE
Fix 'globaly' typo and minor rewordings

### DIFF
--- a/src/data/about.md
+++ b/src/data/about.md
@@ -1,16 +1,16 @@
-JumboCode is an organization dedicated to helping non-profits by providing them free, custom, technology to aid their services. JumboCode is based out of Tufts University, and works primarily with non-profits in the greater Boston area. JumboCode was founded in 2015, and is 100% run by volunteers.
+JumboCode is an organization dedicated to helping non-profits by providing them free, custom, technology to aid their services. JumboCode is based out of Tufts University and works primarily with non-profits in the greater Boston area. The club was founded in 2015 and is 100% run by student volunteers.
 
 ### Our Goals
 
-We have two main goals encompassing our work:
+There are two main goals that encompass our work:
 
 1. To support local communities in social and civic endeavorments
 2. To empower students with the technological skills to be impactful
 
 ### Our Process
 
-JumboCode projects run throughout the academic school year. In the summer, we work with non-profits to gauge their needs, and workshop potential technological solutions. Well fitting projects are assigned a project lead, who then begins working more closely with their client to plan out their project. Near the end of the summer, project leads begin developing architecture bases for their code bases.
+JumboCode projects run throughout the academic school year. In the summer, we work with non-profit organizations to gauge their needs, and brainstorm potential technological solutions. Well-fitting projects are assigned a project lead, who then begins working more closely with their client to plan out the project. Near the end of the summer, project leads begin developing architecture bases for their code bases.
 
-Teams of ~10 students, from a variety of development, design, and management backgrounds, are formed in September. These teams work closely with their clients to develop, deploy, test, and iterate on their projects during the next 9 months.
+Teams of around 10 students from a variety of development, design, and management backgrounds are formed in September. These teams work with their client non-profits to develop, deploy, test, and iterate on their projects over the next 9 months.
 
-Projects typically start testing with clients in the begining of the Spring semester in mid Janurary, and hand off completely by the end of the academic year, in late April.
+Projects typically start testing with clients in the begining of the Spring semester in mid-Janurary and are handed off completely by the end of the academic year in late April.

--- a/src/sections/Landing.js
+++ b/src/sections/Landing.js
@@ -47,7 +47,7 @@ const LandingPage = () => {
     'Empowering Students',
     'Supporting Non-Profits',
     'Volunteering Locally',
-    'Impacting Globaly',
+    'Impacting Globally',
     'Building Custom Technology',
   ];
   return (


### PR DESCRIPTION
__Description:__

"Globaly" -> "Globally" in `Landing.js`.

Minor rewording and grammar changes in `about.md`. Some of these changes are definitely subjective so I'm very open to reverting or going with something else. 

I might have missed a few things (or introduced them with my changes), so a general once-over of the text is probably worth doing before approving.

Closes #11 .